### PR TITLE
Modify the code to make ATT feed worked

### DIFF
--- a/Source/DiscordIntelBot.py
+++ b/Source/DiscordIntelBot.py
@@ -58,7 +58,10 @@ def FnGetRssFromUrl(RssItem, HookChannelDesciptor):
 
     for RssObject in NewsFeed.entries:
 
-        DateActivity = time.strftime('%Y-%m-%dT%H:%M:%S', RssObject.published_parsed)
+         try:
+            DateActivity = time.strftime('%Y-%m-%dT%H:%M:%S', RssObject.published_parsed)
+        except: 
+            DateActivity = time.strftime('%Y-%m-%dT%H:%M:%S', RssObject.updated_parsed)
         TmpObject = FileConfig.get('main', RssItem[1])
         if "?" in TmpObject:
             IsInitialRun = True


### PR DESCRIPTION
ATT feed doesn't use the standard "pubdate" (published_parsed) but dc:date (updated_parsed). 

So if there is no **pubdate** the bot will read the **dc:date** 

This code is "quick & dirty" but works with [my own bot for MS-Teams](https://github.com/JMousqueton/CTI-MSTeams-Bot ) inspired by ours : 

The code can be improved by managing error if neither pubdate nor dc:date is found. 